### PR TITLE
Add required packages to package.json

### DIFF
--- a/leaderboard/package.json
+++ b/leaderboard/package.json
@@ -3,8 +3,11 @@
   "version": "0.1.0",
   "private": true,
   "dependencies": {
+    "material-ui": "^0.18.1",
     "react": "^15.5.4",
-    "react-dom": "^15.5.4"
+    "react-dom": "^15.5.4",
+    "react-material-ui-form-validator": "^0.3.2",
+    "react-tap-event-plugin": "^2.0.1"
   },
   "devDependencies": {
     "react-scripts": "1.0.7"


### PR DESCRIPTION
When installing node packages like `material-ui`, use the `--save` flag:

```shell
$ npm install --save material-ui
```

That adds the package both to your _local_ version of the project, _as well as_ to the `package.json` file, which serves as a manifest for other users. 

**Now, other developers can clone this GitHub repository and run `npm i` from the app directory** (with _no arguments_) and it will look inside the `package.json` file for which packages you require, and install them all automatically.

It doesn't matter as much in small projects, but in large projects with dozens of requirements, this prevents new developers from having to slog through hundreds or thousands of error-messages to find which packages are missing.